### PR TITLE
Make the welcome message contribution guide link configurable per repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,38 @@ To run tests, make sure the test-requirements are installed by running:
 Once the dependencies are installed, you can run tests by executing:
 
     $ nosetests
+
+Adding a Project
+================
+
+To make rust-highfive interact with a new repo, add a configuration file in
+`highfive/configs`, with a filename of the form `reponame.json`. 
+
+It should look like:
+
+```
+{
+    "groups":{
+        "all": ["@username", "@otheruser"],
+        "subteamname": ["@subteammember", "@username"]
+    },
+    "dirs":{
+        "dirname":  ["subteamname", "@anotheruser"]
+    }
+    "contributing": "http://project.tld/contributing_guide.html"
+}   
+```
+
+The `groups` section allows you to alias lists of usernames. You should
+specify at least one user in the group "all"; others are optional.
+
+The `dirs` section is where you map directories of the repo to users or
+groups who're eligible to review PRs affecting it. This section can be left
+blank.
+
+`contributing` specifies the contribution guide link in the message which
+welcomes new contributors to the repository. If `contributing` is not
+present, the [Rust contributing.md][rustcontrib] will be linked instead. 
+
+[rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
+

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -30,16 +30,19 @@ raw_welcome = """Thanks for the pull request, and welcome! The Rust team is exci
 
 If any changes to this PR are deemed necessary, please add them as extra commits. This ensures that the reviewer can see what has changed since they last reviewed the code. The way Github handles out-of-date commits, this should also make it reasonably obvious what issues have or haven't been addressed. Large or tricky changes may require several passes of review and changes.
 
-Please see [CONTRIBUTING.md](https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md) for more information.
+Please see [the contribution instructions](%s) for more information.
 """
 
 
-def welcome_msg(reviewer):
+def welcome_msg(reviewer, link):
     if reviewer is None:
         text = welcome_without_reviewer
     else:
         text = welcome_with_reviewer % reviewer
-    return raw_welcome % text
+    # Default to the Rust contribution guide if "contributing" wasn't set
+    if not link:
+        link = "https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md"
+    return raw_welcome % (text, link)
 
 warning_summary = '<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>\n\n%s'
 unsafe_warning_msg = 'These commits modify **unsafe code**. Please review it carefully!'
@@ -297,6 +300,11 @@ def get_irc_nick(gh_name):
             return rustacean_data[0].get("irc")
     return None
 
+# Find the contribution instructions link for the repo, if there is one
+def find_contrib_link(repo):
+    repoinfo = _load_json_file(repo + '.json')
+    return repoinfo.get('contributing')
+ 
 
 def new_pr(payload, user, token):
     owner = payload['pull_request']['base']['repo']['owner']['login']
@@ -317,7 +325,7 @@ def new_pr(payload, user, token):
     set_assignee(reviewer, owner, repo, issue, user, token, author)
 
     if is_new_contributor(author, owner, repo, user, token):
-        post_comment(welcome_msg(reviewer), owner, repo, issue, user, token)
+        post_comment(welcome_msg(reviewer, find_contrib_link(repo)), owner, repo, issue, user, token)
     elif post_msg:
         post_comment(review_msg(reviewer, author), owner, repo, issue, user, token)
 

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -13,8 +13,11 @@ class TestNewPR(base.BaseTest):
 
     def test_choose_reviewer(self):
         normal_diff = self._load_fake('normal.diff')
+        fake_config = { "groups": {"all":["@pnkfelix", "@nrc"]}, 
+                        "dirs":   {} }
         reviewer = newpr.choose_reviewer('rust',
                                          'rust-lang',
                                          normal_diff,
-                                         'nikomatsakis')
+                                         'nikomatsakis',
+                                         fake_config)
         self.assertNotEqual('nikomatsakis', reviewer)


### PR DESCRIPTION
An example of why this is needed is how rust-buildbot doesn't use the same contribution workflow as Rust, yet the welcome message links new contributors to the Rust guide. https://github.com/rust-lang/rust-buildbot/pull/9

With this change, I'll be able to write a quick contribution guide to the rust-buildbot repo, add it to the highfive config, and it'll be linked whenever a new contributor submits a PR to rust-buildbot.