### PR TITLE
Warn if PR is against unexpected branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ It should look like:
     },
     "dirs":{
         "dirname":  ["subteamname", "@anotheruser"]
-    }
-    "contributing": "http://project.tld/contributing_guide.html"
+    },
+    "contributing": "http://project.tld/contributing_guide.html",
+    "expected_branch": "develop"
 }   
 ```
 
@@ -58,6 +59,11 @@ blank.
 `contributing` specifies the contribution guide link in the message which
 welcomes new contributors to the repository. If `contributing` is not
 present, the [Rust contributing.md][rustcontrib] will be linked instead. 
+
+If PRs should be filed against a branch other than `master`, specify the
+correct destination in the `expected_branch` field. If `expected_branch` is
+left out, highfive will assume that PRs should be filed against `master` and
+post a warning if they're against some other branch.
 
 [rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Github hooks to provide an encouraging atmosphere for new contributors
 Install
 =======
 
-To install `highfive` you just need to execute the `setup.py` script or use `pip` directly. Both commands have to be executed from the directory where the `setup.py` script is located.
+To install `highfive` you just need to execute the `setup.py` script or use
+`pip` directly. Both commands have to be executed from the directory where the
+`setup.py` script is located.
 
     $ python setup.py install
 
@@ -62,8 +64,8 @@ present, the [Rust contributing.md][rustcontrib] will be linked instead.
 
 If PRs should be filed against a branch other than `master`, specify the
 correct destination in the `expected_branch` field. If `expected_branch` is
-left out, highfive will assume that PRs should be filed against `master` and
-post a warning if they're against some other branch.
+left out, highfive will assume that PRs should be filed against `master`. 
+The bot posts a warning on any PR that targets an unexpected branch.
 
 [rustcontrib]: https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md 
 

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -291,8 +291,9 @@ def modifies_submodule(diff):
     return False
 
 def unexpected_branch(payload, config):
-    # Does the target branch of the PR (from payload) differ from the expected
-    # branch in the config? If unspecified, assume master. 
+    """ returns (expected_branch, actual_branch) if they differ, else None 
+    """
+    # If unspecified, assume master. 
     expected_target = config["expected_branch"]
     if not expected_target: 
         expected_target = "master"

--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -48,6 +48,8 @@ def welcome_msg(reviewer, config):
 warning_summary = '<img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20> **Warning** <img src="http://www.joshmatthews.net/warning.svg" alt="warning" height=20>\n\n%s'
 unsafe_warning_msg = 'These commits modify **unsafe code**. Please review it carefully!'
 submodule_warning_msg = 'These commits modify **submodules**.'
+surprise_branch_warning = "Pull requests are usually filed against the %s branch for this repo, but this one is against %s. Please double check that you specified the right target!"
+
 
 review_with_reviewer = 'r? @%s\n\n(rust_highfive has picked a reviewer for you, use r? to override)'
 review_without_reviewer = '@%s: no appropriate reviewer found, use r? to override'
@@ -288,6 +290,20 @@ def modifies_submodule(diff):
         return True
     return False
 
+def unexpected_branch(payload, config):
+    # Does the target branch of the PR (from payload) differ from the expected
+    # branch in the config? If unspecified, assume master. 
+    expected_target = config["expected_branch"]
+    if not expected_target: 
+        expected_target = "master"
+
+    # ie we want "stable" in this: "base": { "label": "rust-lang:stable"...
+    actual_target = payload['pull_request']['base']['label'].split(':')[1]
+
+    if expected_target != actual_target:
+        return (expected_target, actual_target)
+    return False
+
 def get_irc_nick(gh_name):
     """ returns None if the request status code is not 200,
      if the user does not exist on the rustacean database,
@@ -330,6 +346,10 @@ def new_pr(payload, user, token):
     # Lets not check for unsafe code for now, it doesn't seem to be very useful and gets a lot of false positives.
     #if modifies_unsafe(diff):
     #    warnings += [unsafe_warning_msg]
+
+    surprise = unexpected_branch(payload, config)
+    if surprise:
+        warnings.append(surprise_branch_warning % surprise)
 
     if modifies_submodule(diff):
         warnings.append(submodule_warning_msgs)


### PR DESCRIPTION
And document it. Fixes issue #50, I think. 

Not sure the best way to test it; maybe we should keep the result of a sample API call in the tests dir and pull it in as the payload? I've noticed that a lot of the JSON parsing features are untested since they're so heavily dependent on the state of the API. 