### PR TITLE
Cease expecting gh-pages branch

### DIFF
--- a/highfive/configs/rust-www.json
+++ b/highfive/configs/rust-www.json
@@ -3,6 +3,5 @@
         "all": ["core"]
     },
     "dirs": {
-    },
-    "expected_branch": "gh-pages"
+    }
 }


### PR DESCRIPTION
per https://github.com/rust-lang/rust-www/issues/148 , master is the real branch now.