### PR TITLE
The expected branch for blog.rust-lang.org is gh-pages

### DIFF
--- a/highfive/configs/blog.rust-lang.org.json
+++ b/highfive/configs/blog.rust-lang.org.json
@@ -2,6 +2,7 @@
     "groups": {
         "all": ["core"]
     },
+    "expected_branch": "gh-pages",
     "dirs": {
     }
 }


### PR DESCRIPTION
**Warning:** this is a bind PR, made in the github editor and completely untested.

In https://github.com/rust-lang/blog.rust-lang.org/pull/93#issuecomment-217219687, @rust-highfive commented:
> Pull requests are usually filed against the master branch for this repo, but this one is against gh-pages. 

But that repository does not have a master branch.