### PR TITLE
Remove aatch from suggested reviewers

### DIFF
--- a/highfive/configs/rust.json
+++ b/highfive/configs/rust.json
@@ -1,7 +1,7 @@
 {
     "groups": {
         "all": [],
-        "compiler": ["@nikomatsakis", "@pnkfelix", "@nrc", "@Aatch", "@eddyb", "@arielb1"],
+        "compiler": ["@nikomatsakis", "@pnkfelix", "@nrc", "@eddyb", "@arielb1"],
         "syntax": ["@nikomatsakis", "@pnkfelix", "@nrc"],
         "libs": ["@aturon", "@alexcrichton", "@brson", "@sfackler"]
     },


### PR DESCRIPTION
They don't always have time, and if a review winds up languishing, that can be a bad thing.

cc @aatch -- no judgment, you do awesome work, just don't want to overwhelm you (and simultaneously to ensure that PRs get timely reviews).