### PR TITLE
Remove trailing comma to make JSON valid

### DIFF
--- a/highfive/configs/rust.json
+++ b/highfive/configs/rust.json
@@ -4,7 +4,7 @@
         "compiler": ["@nikomatsakis", "@pnkfelix", "@eddyb", "@arielb1", "@petrochenkov", "@estebank", "@michaelwoerister"],
         "syntax": ["@nikomatsakis", "@pnkfelix", "@petrochenkov", "@michaelwoerister", "@eddyb", "@arielb1"],
         "libs": ["@KodrAus", "@alexcrichton", "@sfackler", "@BurntSushi", "@dtolnay", "@JoshTriplett", "@rkruppe", "@bluss", "@kimundi", "@withoutboats", "@cramertj", "@shepmaster", "@Mark-Simulacrum", "@TimNN", "@kennytm", "@aidanhs"],
-        "doc": ["@steveklabnik", "@QuietMisdreavus"],
+        "doc": ["@steveklabnik", "@QuietMisdreavus"]
     },
     "dirs": {
         "doc":              ["doc"],


### PR DESCRIPTION
This might fix why highfive isn't assigning PRs? h/t @kennytm