### PR TITLE
Add reminder about review in welcome msg

### DIFF
--- a/highfive/newpr.py
+++ b/highfive/newpr.py
@@ -23,6 +23,8 @@ welcome_without_reviewer = "@nrc (NB. this repo may be misconfigured)"
 raw_welcome = """Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from %s soon.
 
 Please see [the contribution instructions](%s) for more information.
+
+Tip: when your PR is ready for review, don't forget to fire up the command `@rustbot ready` to put your PR in the review queue of your assigned reviewer: this will help speed up the overall review process.
 """
 
 warning_summary = ':warning: **Warning** :warning:\n\n%s'

--- a/highfive/tests/test_integration_tests.py
+++ b/highfive/tests/test_integration_tests.py
@@ -103,7 +103,7 @@ class TestNewPr(object):
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
                     {
-                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n"}
+                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n\nTip: when your PR is ready for review, don't forget to fire up the command `@rustbot ready` to put your PR in the review queue of your assigned reviewer: this will help speed up the overall review process.\n"}
                 ),
                 {'body': {}},
             ),
@@ -145,7 +145,7 @@ class TestNewPr(object):
                 (
                     'POST', newpr.post_comment_url % ('rust-lang', 'rust', '7'),
                     {
-                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n"}
+                        'body': "Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from @nrc (or someone else) soon.\n\nPlease see [the contribution instructions](https://rustc-dev-guide.rust-lang.org/contributing.html) for more information.\n\nTip: when your PR is ready for review, don't forget to fire up the command `@rustbot ready` to put your PR in the review queue of your assigned reviewer: this will help speed up the overall review process.\n"}
                 ),
                 {'body': {}},
             ),

--- a/highfive/tests/test_newpr.py
+++ b/highfive/tests/test_newpr.py
@@ -113,6 +113,8 @@ class TestNewPRGeneral(TestNewPR):
         base_msg = """Thanks for the pull request, and welcome! The Rust team is excited to review your changes, and you should hear from %s soon.
 
 Please see [the contribution instructions](%s) for more information.
+
+Tip: when your PR is ready for review, don't forget to fire up the command `@rustbot ready` to put your PR in the review queue of your assigned reviewer: this will help speed up the overall review process.
 """
 
         # No reviewer, no config contributing link.


### PR DESCRIPTION
This additional note would like to help contributors to promptly request a review when done with a set of changes, the goal is to try reducing the time it takes for the PR to reach the assigned reviewer review queue.

Discussed on [Zulip](https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/Rust.20highfive.20suggest.20how.20to.20request.20review/near/291165030).

I'm not sure about the exact wording :)

r? @Mark-Simulacrum 